### PR TITLE
Compatibility with Matplotlib 3.5.0

### DIFF
--- a/dpcmaps/dpc.py
+++ b/dpcmaps/dpc.py
@@ -253,7 +253,7 @@ def recon(gx, gy, dx=0.1, dy=0.1, pad=1, w=1.0):
     c = -1j * (kappax * tx + w * kappay * ty)
 
     c = np.ma.masked_values(c, 0)
-    c /= kappax ** 2 + w * kappay ** 2
+    c /= kappax**2 + w * kappay**2
     c = np.ma.filled(c, 0)
 
     c = np.fft.ifftshift(c)

--- a/dpcmaps/dpc_gui.py
+++ b/dpcmaps/dpc_gui.py
@@ -65,7 +65,7 @@ from skimage import exposure
 import numpy as np
 import matplotlib as mpl
 
-from matplotlib.backends.backend_qt4agg import (
+from matplotlib.backends.backend_qtagg import (
     FigureCanvasQTAgg as FigureCanvas,
     NavigationToolbar2QT as NavigationToolbar,
 )
@@ -380,7 +380,7 @@ class DPCWindow(QMainWindow):
         QMainWindow.__init__(self, parent)
         DPCWindow.instance = self
 
-        self.bin_num = 2 ** 16
+        self.bin_num = 2**16
         self._thread = None
         self.ion_data = None
         self.bad_flag = 0
@@ -868,7 +868,7 @@ class DPCWindow(QMainWindow):
             self.strap_end,
         ]:
             w.setMinimum(0)
-            w.setMaximum(int(2 ** 31 - 1))
+            w.setMaximum(int(2**31 - 1))
             try:
                 w.setDecimals(3)
             except Exception:

--- a/dpcmaps/dpc_kernel.py
+++ b/dpcmaps/dpc_kernel.py
@@ -403,7 +403,7 @@ def recon(gx, gy, dx=0.1, dy=0.1, pad=1, w=1.0):
     c = -1j * (kappax * tx + w * kappay * ty)
 
     c = np.ma.masked_values(c, 0)
-    c /= kappax ** 2 + w * kappay ** 2
+    c /= kappax**2 + w * kappay**2
     c = np.ma.filled(c, 0)
 
     c = np.fft.ifftshift(c)


### PR DESCRIPTION
Compatibility with Matplotlib 3.5.0: `backend_qt5agg` is deprecaed and no longer supported, changed to `backend_qtagg`.