### PR TITLE
CI: Harden GHA configuration

### DIFF
--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -7,6 +7,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+        with:
+          persist-credentials: false
       - uses: actions/setup-python@v2
       - name: Install Dependencies
         run: |

--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -1,4 +1,6 @@
 name: Style - BLACK
+permissions:
+  contents: read
 
 on: [push, pull_request]
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -13,6 +13,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+      with:
+        persist-credentials: false
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v2
       with:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,4 +1,6 @@
 name: Documentation
+permissions:
+  contents: read
 
 on: [push, pull_request]
 

--- a/.github/workflows/docs_publish.yml
+++ b/.github/workflows/docs_publish.yml
@@ -21,6 +21,8 @@ jobs:
         export REPOSITORY_NAME=${GITHUB_REPOSITORY#*/}
         echo "REPOSITORY_NAME=${REPOSITORY_NAME}" >> $GITHUB_ENV
     - uses: actions/checkout@v2
+      with:
+        persist-credentials: false
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v2
       with:

--- a/.github/workflows/docs_publish.yml
+++ b/.github/workflows/docs_publish.yml
@@ -45,7 +45,7 @@ jobs:
     - name: Deploy documentation to nsls-ii.github.io
       # We pin to the SHA, not the tag, for security reasons.
       # https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/security-hardening-for-github-actions#using-third-party-actions
-      uses: peaceiris/actions-gh-pages@bbdfb200618d235585ad98e965f4aafc39b4c501  # v3.7.3
+      uses: peaceiris/actions-gh-pages@bbdfb200618d235585ad98e965f4aafc39b4c501 # v3.7.3
       with:
         deploy_key: ${{ secrets.ACTIONS_DOCUMENTATION_DEPLOY_KEY }}
         publish_branch: master

--- a/.github/workflows/flake8.yml
+++ b/.github/workflows/flake8.yml
@@ -7,6 +7,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+        with:
+          persist-credentials: false
       - uses: actions/setup-python@v2
       - name: Install Dependencies
         run: |

--- a/.github/workflows/flake8.yml
+++ b/.github/workflows/flake8.yml
@@ -1,4 +1,6 @@
 name: Style - FLAKE8
+permissions:
+  contents: read
 
 on: [push, pull_request]
 

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -16,6 +16,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+      with:
+        persist-credentials: false
     - name: Set up Python
       uses: actions/setup-python@v2
       with:

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -1,4 +1,6 @@
 name: Tests
+permissions:
+  contents: read
 
 on:
   push:

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -36,6 +36,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+      with:
+        persist-credentials: false
 
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v2

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -45,7 +45,7 @@ jobs:
         # This step is not expected to influence the test, since the test is run in Conda environment
         python-version: 3.9
 
-    - uses: conda-incubator/setup-miniconda@v2
+    - uses: conda-incubator/setup-miniconda@9f54435e0e72c53962ee863144e47a4b094bfd35 # v2
       with:
         channels: conda-forge
         channel-priority: flexible


### PR DESCRIPTION
Apply recommended hardening steps including:

- pinning to a SHA any actions used
- not persisting the read token on checkout
- setting the default permissions to read-only
